### PR TITLE
Pin pyamps coefficient version in tests

### DIFF
--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -12,7 +12,7 @@ jobs:
   build:
     name: Build and Test
     runs-on: ubuntu-latest
-    container: ghcr.io/dynamit-uib/pynamit:x86_64-2025-05-07
+    container: ghcr.io/dynamit-uib/pynamit:x86_64-2025-05-08
     defaults:
       run:
         shell: 'bash -leo pipefail {0}'

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,13 +49,8 @@ RUN mamba create -y -n pynamit-env \
     sphinx-rtd-theme && \
     echo "mamba activate pynamit-env" >> /etc/profile.d/activate_env.sh
 
-# Install pyamps 1.6, as field-aligned currents are different in 1.7
-RUN pip install "pyamps==1.6"
-
 # Install Lompe
 RUN pip install "lompe[deps-from-github,extras] @ git+https://github.com/klaundal/lompe.git@main"
 
 # Install pyHWM14
 RUN pip install "git+https://github.com/rilma/pyHWM14.git@main"
-
-WORKDIR /

--- a/src/pynamit/default_run.py
+++ b/src/pynamit/default_run.py
@@ -79,6 +79,8 @@ def run_pynamit(
         The dynamics object for performing the simulation and handling
         the simulation results.
     """
+    import os
+
     import datetime
     import numpy as np
 
@@ -125,7 +127,19 @@ def run_pynamit(
     jr_lat = dynamics.state_grid.lat
     jr_lon = dynamics.state_grid.lon
     d = dipole.Dipole(date.year)
-    a = pyamps.AMPS(300, 0, -4, 20, 100, minlat=50)
+    a = pyamps.AMPS(
+        300,
+        0,
+        -4,
+        20,
+        100,
+        minlat=50,
+        coeff_fn=os.path.join(
+            os.path.dirname(pyamps.__file__),
+            "coefficients",
+            "SW_OPER_MIO_SHA_2E_00000000T000000_99999999T999999_0104.txt",
+        ),
+    )
     jr = a.get_upward_current(mlat=jr_lat, mlt=d.mlon2mlt(jr_lon, date)) * 1e-6
     # Filter low latitude jr.
     jr[np.abs(jr_lat) < 50] = 0


### PR DESCRIPTION
Allows for consistent test results across pyamps versions (>= 1.6).